### PR TITLE
virts-509-update agent executors on heartbeat (#593)

### DIFF
--- a/app/service/agent_svc.py
+++ b/app/service/agent_svc.py
@@ -73,6 +73,7 @@ class AgentService(BaseService):
             if agent[0]['trusted']:
                 update_data['last_trusted_seen'] = now
             await self.data_svc.update('core_agent', 'paw', paw, data=update_data)
+            await self.data_svc.update_agent_executor(agent[0]['id'], executors, agent[0]['executors'])
         else:
             queued = dict(last_seen=now, paw=paw, platform=platform, server=server, host_group=group,
                           location=location, architecture=architecture, pid=pid, ppid=ppid,

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -4,7 +4,7 @@ CREATE TABLE if not exists core_payload (ability integer, payload text, UNIQUE (
 CREATE TABLE if not exists core_adversary (id integer primary key AUTOINCREMENT, adversary_id text, name text, description text, UNIQUE (adversary_id));
 CREATE TABLE if not exists core_adversary_map (id integer primary key AUTOINCREMENT, phase integer, adversary_id text, ability_id text, UNIQUE (adversary_id, phase, ability_id));
 CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, architecture text, platform text, server text, host_group text, location text, pid integer, ppid integer, trusted integer, last_trusted_seen date, sleep_min integer, sleep_max integer);
-CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer);
+CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer, UNIQUE(agent_id, executor) ON CONFLICT REPLACE);
 CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, autonomous integer, planner integer, state text, allow_untrusted integer);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, module text, UNIQUE(ability, module) ON CONFLICT REPLACE);


### PR DESCRIPTION
* virts-509-update agent executors on heartbeat
If agent heartbeat now has changed executors and/or priorities for
executors, handle_heartbeat function now updates the executors in the
database.

* virts-509-update agent executors on heartbeat
    If agent heartbeat now has changed executors and/or preference for
    executors, handle_heartbeat function now updates the executors in the
    database utilizing update_agent function defined in data_svc.py.

* virts-509-update agent executors on heartbeat
reworked data_svc function, now only removes executor from database if
it is not in the new and incoming executors from heartbeat. If new
executor is not in database, it is also added.

* virts-509-update agent executors on heartbeat
Instead of changing the incoming executors list into dictionaries with
preferred keys/values, list of dictionaries is now converted into an
ordered list where first item is given preference. This allows for set
operations.

* virts-509-update agent executors on heartbeat
Utilizing the update function. Update function should be updated to be
able to more easily intake various keys for granular control of which
items need to be updated especially if they share agent_ids

* virts-509-update agent executors on heartbeat
Modified conf/core.sql to make agent_id,executor combinations
unique, now when we add an agent_id/executor combination to the table,
if it already exists it replaces it and thus updates the preferred
field.